### PR TITLE
Fix/safari dateparse issue

### DIFF
--- a/src/utils/dataParser.ts
+++ b/src/utils/dataParser.ts
@@ -6,7 +6,7 @@ export function parseGoogleSheetsApiResponse(
   return sheets.sheets.reduce((acc: ParsedGoogleSheets, sheet) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [_, title] = sheet.properties.title.split(':');
-    if (!isNaN(Date.parse(sheet.properties.title))) {
+    if (!isNaN(Date.parse(title))) {
       acc[title.trim()] = flattenSheet(sheet.data[0].rowData);
     }
 


### PR DESCRIPTION
error happened in safari, Date.parse couldn't handle such string "date: 2020-01"
![Screenshot 2020-04-01 at 11 15 20](https://user-images.githubusercontent.com/14156322/78121707-01644700-740c-11ea-8702-ecf7d5554a7f.png)
