### PR TITLE
remove e2e from prepush

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "CI=true yarn run test && yarn run cy:run"
+      "pre-push": "CI=true yarn run test"
     }
   }
 }


### PR DESCRIPTION
e2e are heavy, and they will run as a part of github actions anyway